### PR TITLE
Added c++14 requirement for it to compile in noetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ set(CMAKE_CXX_COMPILER "g++")
 
 project(phoxi_camera)
 
+set(CMAKE_CXX_STANDARD 14)
+
 find_package(PhoXi REQUIRED CONFIG PATHS "$ENV{PHOXI_CONTROL_PATH}")
 
 find_package(catkin REQUIRED


### PR DESCRIPTION
Tested in 18.04 machine that the c++14 compiles fine. This is necessary in 20.04 to compile with PCL.